### PR TITLE
Add express server and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Lancetoi
+
+This repository contains a simple landing page in French. A minimal Express
+server is provided along with a Jest test to ensure the page is served correctly.
+
+## Development
+
+Install dependencies and start the server:
+
+```bash
+npm install
+npm start
+```
+
+The page will be available on [http://localhost:3000](http://localhost:3000).
+
+## Testing
+
+Run the test suite with:
+
+```bash
+npm test
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Lance toi sans hésiter</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      margin: 0;
+      font-family: 'Segoe UI', sans-serif;
+      background: #f9f9f9;
+      color: #333;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      padding: 2rem;
+    }
+    .container {
+      background: white;
+      border-radius: 1rem;
+      box-shadow: 0 8px 16px rgba(0,0,0,0.1);
+      padding: 2rem;
+      max-width: 600px;
+      text-align: center;
+    }
+    h1 {
+      color: #005b96;
+    }
+    p {
+      font-size: 1.1rem;
+      line-height: 1.6;
+    }
+    button {
+      margin-top: 1.5rem;
+      padding: 0.8rem 1.5rem;
+      font-size: 1rem;
+      border: none;
+      background-color: #005b96;
+      color: white;
+      border-radius: 0.5rem;
+      cursor: pointer;
+    }
+    button:hover {
+      background-color: #003f6f;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Lance toi sans hésiter</h1>
+    <p>Un accompagnement simple et rassurant pour t’aider à lancer tes projets, étape par étape. Aucun jargon, aucun risque. Juste toi, tes idées, et une méthode claire.</p>
+    <button>Commencer maintenant</button>
+  </div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "lancetoi",
+  "version": "1.0.0",
+  "description": "Sample landing page",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+
+app.use(express.static(__dirname));
+
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('GET /', () => {
+  it('responds with html', async () => {
+    const res = await request(app).get('/');
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toMatch(/html/);
+  });
+});


### PR DESCRIPTION
## Summary
- add `index.html` landing page
- create Express `server.js`
- configure `package.json` with Jest and Supertest
- add basic test verifying the landing page loads
- document usage in `README`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c5acc7514832b9989b9bb804dbc95